### PR TITLE
Pagination needs a key prop

### DIFF
--- a/components/Pagination.js
+++ b/components/Pagination.js
@@ -19,7 +19,7 @@ export default function Pagination({ currentPage, numPages }) {
           </Link>
         )}
         {Array.from({ length: numPages }, (_, i) => (
-          <Link href={`/blog/page/${i + 1}`}>
+          <Link href={`/blog/page/${i + 1}`} key={`page-${i}`}>
             <li className='relative block py-2 px-3 leading-tight bg-white border border-gray-300 text-gray-800 mr-1 hover:bg-gray-200 cursor-pointer'>
               {i + 1}
             </li>


### PR DESCRIPTION
This fixes the warning
`Each child in a list should have a unique "key" prop `
In the Pagination component.